### PR TITLE
Update cifar10_input.py to work on version 0.12.0-rc1

### DIFF
--- a/tutorials/image/cifar10/cifar10_input.py
+++ b/tutorials/image/cifar10/cifar10_input.py
@@ -84,13 +84,13 @@ def read_cifar10(filename_queue):
 
   # The first bytes represent the label, which we convert from uint8->int32.
   result.label = tf.cast(
-      tf.strided_slice(record_bytes, [0], [label_bytes]), tf.int32)
+      tf.slice(record_bytes, [0], [label_bytes]), tf.int32)
 
   # The remaining bytes after the label represent the image, which we reshape
   # from [depth * height * width] to [depth, height, width].
   depth_major = tf.reshape(
-      tf.strided_slice(record_bytes, [label_bytes],
-                       [label_bytes + image_bytes]),
+      tf.slice(record_bytes, [label_bytes],
+                       [image_bytes]),
       [result.depth, result.height, result.width])
   # Convert from [depth, height, width] to [height, width, depth].
   result.uint8image = tf.transpose(depth_major, [1, 2, 0])


### PR DESCRIPTION
I'm working with `models/tutorials/image/cifar10/`.

There is an error `strided_slice() missing 1 required positional argument: 'strides'` when I run the command `python cifar10_train.py` under the version of 0.12.0-rc1. Although the [document](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/g3doc/api_docs/python/functions_and_classes/shard8/tf.strided_slice.md) said `strides` is optional.

So I replaced `strided_slice` with `slice` to make it work as a temporary solution.